### PR TITLE
Support for running inside kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,23 +3,26 @@ ARG GOLANG_VERSION=1.24.1-bullseye
 
 FROM golang:${GOLANG_VERSION} AS build
 WORKDIR /app
-RUN apt update && apt install -y curl \
+RUN apt update && apt install -y curl git \
     && curl -fsSL https://deb.nodesource.com/setup_23.x | bash - \
     && apt install -y nodejs \
     && npm install -g npm@latest \
     && rm -rf /var/lib/apt/lists/*
-COPY . .
-RUN cd go-server && go build
-RUN cd trivy-dashboard && npm install && npm run build
+RUN git clone "https://github.com/locustbaby/trivy-ui.git"
+RUN cd trivy-ui/go-server && go build -o go-server
+RUN cd trivy-ui/trivy-dashboard && npm install && npm run build
 
 
 FROM debian:bullseye-slim
+
+ARG IMAGE_VERSION
+
 WORKDIR /app
-COPY --from=build /app/go-server/go-server /app/go-server
-COPY --from=build /app/trivy-dashboard/build /app/trivy-dashboard/build
+COPY --from=build /app/trivy-ui/go-server/go-server /app/go-server
+COPY --from=build /app/trivy-ui/trivy-dashboard/dist /app/trivy-dashboard/dist
 RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
-LABEL org.opencontainers.image.description "This image contains Backend Trivy UI (https://github.com/locustbaby/trivy-ui)"
+LABEL org.opencontainers.image.description "This image contains Backend Trivy UI"
 LABEL org.opencontainers.image.url "https://github.com/llocustbaby/trivy-ui"
 LABEL org.opencontainers.image.documentation "https://github.com/locustbaby/trivy-ui/blob/main/README.md"
 LABEL org.opencontainers.image.authors "https://github.com/locustbaby"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,17 +14,12 @@ RUN cd trivy-ui/trivy-dashboard && npm install && npm run build
 
 
 FROM debian:bullseye-slim
-
-ARG IMAGE_VERSION
-
 WORKDIR /app
 COPY --from=build /app/trivy-ui/go-server/go-server /app/go-server
 COPY --from=build /app/trivy-ui/trivy-dashboard/dist /app/trivy-dashboard/dist
 RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
-LABEL org.opencontainers.image.description "This image contains Backend Trivy UI"
-LABEL org.opencontainers.image.url "https://github.com/llocustbaby/trivy-ui"
-LABEL org.opencontainers.image.documentation "https://github.com/locustbaby/trivy-ui/blob/main/README.md"
+LABEL org.opencontainers.image.description "This image contains Trivy UI"
 LABEL org.opencontainers.image.authors "https://github.com/locustbaby"
 LABEL org.opencontainers.image.source "https://github.com/locustbaby/trivy-ui"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+ARG NODE_VERSION=23.10.0-alpine3.21
+ARG GOLANG_VERSION=1.24.1-bullseye
+
+FROM golang:${GOLANG_VERSION} AS build
+WORKDIR /app
+RUN apt update && apt install -y curl \
+    && curl -fsSL https://deb.nodesource.com/setup_23.x | bash - \
+    && apt install -y nodejs \
+    && npm install -g npm@latest \
+    && rm -rf /var/lib/apt/lists/*
+COPY . .
+RUN cd go-server && go build
+RUN cd trivy-dashboard && npm install && npm run build
+
+
+FROM debian:bullseye-slim
+WORKDIR /app
+COPY --from=build /app/go-server/go-server /app/go-server
+COPY --from=build /app/trivy-dashboard/build /app/trivy-dashboard/build
+RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+LABEL org.opencontainers.image.description "This image contains Backend Trivy UI (https://github.com/locustbaby/trivy-ui)"
+LABEL org.opencontainers.image.url "https://github.com/llocustbaby/trivy-ui"
+LABEL org.opencontainers.image.documentation "https://github.com/locustbaby/trivy-ui/blob/main/README.md"
+LABEL org.opencontainers.image.authors "https://github.com/locustbaby"
+LABEL org.opencontainers.image.source "https://github.com/locustbaby/trivy-ui"
+
+CMD ["/app/go-server"]
+EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: trivy-ui
+EOF
 ```
 
 2. Deploy the Trivy UI application
@@ -192,6 +193,7 @@ spec:
   - hosts:
     - trivy-ui.example.com
     secretName: trivy-ui-tls
+EOF
 ```
 
 ## Environment Variables

--- a/README.md
+++ b/README.md
@@ -66,6 +66,134 @@ go build
 ```
 4. Access the dashboard at http://localhost:8080
 
+### Run into Kubernetes
+1. Create a ServiceAccount and ClusterRoleBinding
+```shell
+kubectl apply -f - <<EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: trivy-ui
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - aquasecurity.github.io
+  resources:
+  - clustercompliancereports
+  - clusterconfigauditreports
+  - clusterinfraassessmentreports
+  - clusterrbacassessmentreports
+  - clustersbomreports
+  - clustervulnerabilityreports
+  - configauditreports
+  - exposedsecretreports
+  - infraassessmentreports
+  - rbacassessmentreports
+  - sbomreports
+  - vulnerabilityreports
+  verbs:
+  - get
+  - list
+EOF
+
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: trivy-ui
+```
+
+2. Deploy the Trivy UI application
+```shell
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: trivy-ui
+  name: trivy-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      appselector: trivy-ui
+  template:
+    metadata:
+      labels:
+        app: trivy-ui
+    spec:
+      containers:
+      - env:
+        - name: STATIC_PATH
+          value: trivy-dashboard/dist
+        image: <image>
+        name: trivy-ui
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 64Mi
+          requests:
+            memory: 64Mi
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+EOF
+```
+
+3. Create Ingress and Service
+```shell
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: trivy-ui
+  name: trivy-ui
+spec:
+    ports:
+    - name: http
+        port: 80
+        targetPort: 8080
+    selector:
+        appselector: trivy-ui
+    type: ClusterIP
+EOF
+
+kubectl apply -f - <<EOF
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+  labels:
+    app: trivy-ui
+  name: trivy-ui
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: trivy-ui.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: trivy-ui
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - trivy-ui.example.com
+    secretName: trivy-ui-tls
+```
+
 ## Environment Variables
 The server can be configured using the following environment variables:
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      appselector: trivy-ui
+      app: trivy-ui
   template:
     metadata:
       labels:
@@ -161,10 +161,10 @@ metadata:
 spec:
     ports:
     - name: http
-        port: 80
-        targetPort: 8080
+      port: 80
+      targetPort: 8080
     selector:
-        appselector: trivy-ui
+      app: trivy-ui
     type: ClusterIP
 EOF
 

--- a/trivy-dashboard/index.html
+++ b/trivy-dashboard/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + Vue</title>
+    <title>Trivy</title>
   </head>
   <body>
     <div id="app"></div>

--- a/trivy-dashboard/package.json
+++ b/trivy-dashboard/package.json
@@ -10,7 +10,9 @@
   },
   "dependencies": {
     "@vicons/ionicons5": "^0.13.0",
-    "vue": "^3.5.13"
+    "vue": "^3.5.13",
+    "naive-ui": "^2.41.0",
+    "axios": "^1.8.4"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",


### PR DESCRIPTION
Thanks! This project has been incredibly useful for me!

However, I found that it lacked sufficient support for running Trivy UI inside Kubernetes. To address this, I made several improvements:

- the Kubernetes client now runs in InCluster mode using Go, allowing it to leverage the service account instead of requiring a kubeconfig. ([Reference](https://github.com/kubernetes/client-go/blob/master/examples/in-cluster-client-configuration/main.go))
- added a `Dockerfile` to package the project into an image for deployment in Kubernetes.
- fixed missing dependencies in `package.json`, which previously prevented the project image from building.
- Renamed the Title to provide more meaningful information on the browser tab.
 
I have also already tested the launch of the project in kubernetes (`ghc.io/obervinov/images/trivy-ui:0.1.0`). It's working.

Since I originally made these changes for my own needs, I’d be glad if they turn out to be useful for the main project. 

